### PR TITLE
Update prototype-template to 3-column layout and add intent docs

### DIFF
--- a/prototypes/prototype-template/INTENT.md
+++ b/prototypes/prototype-template/INTENT.md
@@ -1,0 +1,40 @@
+# Prototype Template — Intent
+
+This template exists to make it easy to explore small economic/idle prototypes without getting lost in plumbing.
+
+It assumes a philosophy:
+- Production takes time
+- Conversion often involves loss
+- External systems can act independently
+- Capital/meta resources are elevated and separate from day-to-day production
+
+It does NOT assume:
+- Infinite growth
+- Perfect efficiency
+- Instant conversion
+- Full institution simulation
+
+## UI Contracts (3 columns)
+
+The default layout is three columns, each a conceptual contract:
+
+- **Left: Capital (Meta)**
+  - Persistent, slow-moving resources (e.g., Florins, Influence)
+  - Upgrades and investments live here
+
+- **Middle: Estate (Production Engine)**
+  - Systems that produce and convert goods over time
+  - Capacity, strain, inefficiency, breakdown
+
+- **Right: Institutions (External)**
+  - Market / Church / Bank / etc.
+  - Systems you interact with but don’t own
+
+## Anti-bloat rule
+
+If you find yourself adding:
+- detailed worker AI
+- complex upgrade trees
+- full institution simulation
+
+Stop and create a new prototype instead of expanding the template.

--- a/prototypes/prototype-template/index.html
+++ b/prototypes/prototype-template/index.html
@@ -18,28 +18,65 @@
 
     <hr class="divider" />
 
-    <section id="production-section" class="section">
-      <div class="section-title">Production</div>
-
-      <div class="row">
-        <div class="label">Olives</div>
-        <div class="value"><span id="olive-count">0</span></div>
+    <div class="layout">
+      <div class="column">
+        <section class="section">
+          <div class="section-title">Capital</div>
+          <div class="row">
+            <div class="label">Capital</div>
+            <div class="value">(placeholder)</div>
+          </div>
+          <div class="muted note">Meta resources live here</div>
+        </section>
       </div>
 
-      <div class="row">
-        <div class="label">OPS</div>
-        <div class="value"><span id="ops-count">0.0</span></div>
+      <div class="column">
+        <section class="section">
+          <div class="section-title">Estate</div>
+
+          <div id="production-section" class="stack">
+            <div class="subsection-title">Production</div>
+
+            <div class="row">
+              <div class="label">Olives</div>
+              <div class="value"><span id="olive-count">0</span></div>
+            </div>
+
+            <div class="row">
+              <div class="label">OPS</div>
+              <div class="value"><span id="ops-count">0.0</span></div>
+            </div>
+
+            <div class="actions">
+              <button id="pick-olive-btn" class="btn btn-primary" type="button">Pick Olive</button>
+            </div>
+          </div>
+
+          <div id="log-section" class="stack">
+            <div class="subsection-title">Log</div>
+            <div id="log" class="log"></div>
+          </div>
+        </section>
       </div>
 
-      <div class="actions">
-        <button id="pick-olive-btn" class="btn btn-primary" type="button">Pick Olive</button>
+      <div class="column">
+        <section class="section">
+          <div class="section-title">Institutions</div>
+          <div class="row">
+            <div class="label">Market</div>
+            <div class="value muted">Inactive</div>
+          </div>
+          <div class="row">
+            <div class="label">Church</div>
+            <div class="value muted">Inactive</div>
+          </div>
+          <div class="row">
+            <div class="label">Bank</div>
+            <div class="value muted">Inactive</div>
+          </div>
+        </section>
       </div>
-    </section>
-
-    <section id="log-section" class="section">
-      <div class="section-title">Log</div>
-      <div id="log" class="log"></div>
-    </section>
+    </div>
   </div>
 
   <!-- Debug Modal -->

--- a/prototypes/prototype-template/static/css/style.css
+++ b/prototypes/prototype-template/static/css/style.css
@@ -33,9 +33,19 @@ html, body {
 }
 
 .container {
-  max-width: 560px;
+  max-width: 1100px;
   margin: 18px auto;
   padding: 0 14px 18px;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.column {
+  min-width: 0;
 }
 
 .topbar {
@@ -70,6 +80,22 @@ h1 {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   margin-bottom: 10px;
+}
+
+.subsection-title {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 6px 0 8px;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.note {
+  margin-top: 8px;
 }
 
 .row {
@@ -153,6 +179,16 @@ h1 {
   color: var(--muted);
   font-size: 12px;
   line-height: 1.4;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .section {
+    margin-top: 10px;
+  }
 }
 
 /* Modal */

--- a/prototypes/prototype-template/static/js/game.js
+++ b/prototypes/prototype-template/static/js/game.js
@@ -3,6 +3,24 @@
 const STORAGE_PREFIX = "TEMPLATE_";
 const STORAGE_KEY = STORAGE_PREFIX + "gameState";
 
+// Prefer time + outcomes over instant conversion.
+// Logs explain loss/delay/causality; they aren’t cosmetic.
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function rollWeighted(outcomes) {
+  const totalWeight = outcomes.reduce((sum, entry) => sum + (entry.weight || 0), 0);
+  if (totalWeight <= 0) return outcomes[0];
+
+  let roll = Math.random() * totalWeight;
+  for (const entry of outcomes) {
+    roll -= entry.weight || 0;
+    if (roll <= 0) return entry;
+  }
+  return outcomes[outcomes.length - 1];
+}
+
 // --- Reset safety ---
 // Prevents the "reset doesn't reset" bug where a still-running interval re-saves state.
 let isResetting = false;


### PR DESCRIPTION
### Motivation
- Bring the prototype-template in line with the project’s 3-column UI philosophy so new prototypes start with a clear Capital / Estate / Institutions contract. 
- Keep the template minimal and documentation-first to avoid accidental addition of gameplay/institution systems. 

### Description
- Add `prototypes/prototype-template/INTENT.md` documenting the template intent, UI contracts (Left: Capital, Middle: Estate, Right: Institutions) and an anti-bloat rule. 
- Restructure `prototypes/prototype-template/index.html` to wrap the app body in a `.layout` containing three `.column` areas and move existing production and log blocks intact into the middle (Estate) column while adding lightweight placeholders in Capital and Institutions. 
- Add responsive layout CSS in `prototypes/prototype-template/static/css/style.css` (`.layout`, `.column`, `.stack`, `.subsection-title`) that shows a three-column grid on desktop and stacks the columns vertically at narrow widths. 
- Add minimal non-mechanical helpers to `prototypes/prototype-template/static/js/game.js`: `clamp(value, min, max)` and `rollWeighted(outcomes)` plus short philosophy comments, and preserved safe reset/storage behavior (only `localStorage.removeItem(STORAGE_KEY)` used). 

### Testing
- Performed a headless smoke test by starting a static server with `python -m http.server 8000` and opening `prototypes/prototype-template/index.html` in Playwright to capture a screenshot, which completed successfully and shows the 3-column layout. 
- Verified key DOM elements (the `#pick-olive-btn`, `#olive-count`, and `#log`) remain present after the restructure via file inspection and the smoke load, indicating the existing template controls still render.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980c1fdae64832e84d0d239b0eb48ea)