### PR TITLE
Update CLAUDEPROMPTS.md for 3-column prototype template and intent rails

### DIFF
--- a/CLAUDEPROMPTS.md
+++ b/CLAUDEPROMPTS.md
@@ -7,7 +7,7 @@ This file contains **copy/paste prompts** for working with Claude while respecti
 ## Starting a New Prototype
 
 ```
-You are helping me spin up a new idle-game prototype.
+You are helping me spin up a new idle-game prototype in this repository.
 
 Follow the Prototype Spin-Up Checklist and repository rules.
 
@@ -16,12 +16,58 @@ Status: EXPERIMENTAL
 Focus: <1–2 focus tags>
 Intent: <one sentence>
 
-Rules:
-- Start from /prototype-template/
-- Rename STORAGE_PREFIX to "<prototypeName>_"
-- Keep STORAGE_KEY = STORAGE_PREFIX + "gameState"
-- Reset removes only STORAGE_KEY
-- Never clear all localStorage
+Hard rules:
+- Start from /prototypes/prototype-template/
+- Create the new prototype at /prototypes/<prototypeName>/
+- Do not modify other prototypes
 
-Do not modify other prototypes.
+Storage rules (must be consistent across all prototypes):
+- Set STORAGE_PREFIX = "<prototypeName>_"
+- Set STORAGE_KEY = STORAGE_PREFIX + "gameState"
+- Reset removes ONLY STORAGE_KEY
+- Never use localStorage.clear() or sessionStorage.clear()
+- All saved keys must derive from STORAGE_PREFIX / STORAGE_KEY
+
+Philosophy rails (inherited from template):
+- UI is three columns:
+  - Left: Capital (meta resources + upgrades / investments)
+  - Middle: Estate (production engine)
+  - Right: Institutions (market / church / bank)
+- Prefer time + outcomes over instant conversion
+- Logs explain loss, delay, and causality; they are not cosmetic
+
+Deliverables:
+1) Copy the template folder to /prototypes/<prototypeName>/
+2) Update title/header text to <prototypeName>
+3) Ensure storage prefix/key + reset behavior follow the rules above
+4) Create /prototypes/<prototypeName>/INTENT.md with:
+   - Core idea (1 paragraph)
+   - Column model (short)
+   - In-scope / Out-of-scope (bullets)
+   - Success criteria (bullets)
+
+Do not add gameplay mechanics unless explicitly asked.
 ```
+
+## Prototype Spin-Up Checklist (fast)
+
+- [ ] Copy `/prototypes/prototype-template/` → `/prototypes/<name>/`
+- [ ] Set `STORAGE_PREFIX = "<name>_"` and `STORAGE_KEY = STORAGE_PREFIX + "gameState"`
+- [ ] Reset deletes only `STORAGE_KEY` (never clears all storage)
+- [ ] Confirm the 3-column layout contract exists (Capital / Estate / Institutions)
+- [ ] Confirm a Log exists and can display messages
+- [ ] Create `/prototypes/<name>/INTENT.md`
+- [ ] Add prototype metadata to the launcher (if applicable)
+
+## Anti-bloat rule
+
+The prototype-template encodes structure and design rails, not gameplay systems.
+
+Do NOT add to the template:
+- shipping logic
+- market logic
+- upgrade trees
+- debt or banking mechanics
+- event tables
+
+If a system is large enough to need rules, it belongs in a prototype.


### PR DESCRIPTION
### Motivation

- Refresh the embedded prompt for `## Starting a New Prototype` so it encodes the project’s 3-column UI model and intent rails.
- Make storage and reset rules explicit to ensure consistent save-key behavior across prototypes via `STORAGE_PREFIX` and `STORAGE_KEY`.
- Provide quick spin-up guidance and an anti-bloat rule to reduce accidental template creep and keep templates focused on structure rather than systems.

### Description

- Replaced the fenced prompt block under `## Starting a New Prototype` in `CLAUDEPROMPTS.md` with an updated verbatim prompt that includes `Hard rules`, `Storage rules`, `Philosophy rails`, and `Deliverables`.
- Standardized storage guidance to require `STORAGE_PREFIX = "<prototypeName>_"`, `STORAGE_KEY = STORAGE_PREFIX + "gameState"`, and forbids `localStorage.clear()` / `sessionStorage.clear()`.
- Added a new `## Prototype Spin-Up Checklist (fast)` section containing a compact checklist for copying the template, storage config, layout checks, logs, and `INTENT.md` creation.
- Appended a new `## Anti-bloat rule` section that lists systems that must not be added to the template (e.g., shipping logic, market logic, upgrade trees, debt/banking, event tables).

### Testing

- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980c643e338832e8863c3c8c68b4d40)