### PR TITLE
Fix save/load hygiene and centralize harvest tuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ env/
 # OS
 .DS_Store
 Thumbs.db
+__MACOSX/
+
+# Node
+node_modules/

--- a/prototypes/treeGroves/TEST_README.md
+++ b/prototypes/treeGroves/TEST_README.md
@@ -123,13 +123,15 @@ Validate expected behavior:
 The harvest weight logic is now centralized in [static/js/harvestWeights.js](static/js/harvestWeights.js):
 
 ```javascript
-import { BASE_HARVEST_OUTCOMES, computeHarvestOutcomeWeights } from './harvestWeights.js';
+import { computeHarvestOutcomeWeights } from './harvestWeights.js';
+import { TUNING } from './static/js/tuning.js';
 
 computeHarvestOutcomeWeights({ 
-  outcomes,        // Base harvest outcomes
+  outcomes: TUNING.harvest.outcomes, // Base harvest outcomes
   harvesterCount,  // Number of harvesters
   arboristIsActive, // Whether arborist is hired
-  upgrades         // Object with upgrade flags
+  upgrades,        // Object with upgrade flags
+  tuning: TUNING.harvest, // Shared tuning constants
 })
 ```
 

--- a/prototypes/treeGroves/harvest-weights.test.js
+++ b/prototypes/treeGroves/harvest-weights.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeHarvestOutcomeWeights, BASE_HARVEST_OUTCOMES } from './test-utils.js';
+import { computeHarvestOutcomeWeights, TUNING } from './test-utils.js';
 
 describe('computeHarvestOutcomeWeights', () => {
   // Helper to sum weights
@@ -11,10 +11,11 @@ describe('computeHarvestOutcomeWeights', () => {
   describe('Conservation: weight sum remains ~1.0 when no clamping occurs', () => {
     it('should conserve weight sum with 0 harvesters, no upgrades', () => {
       const result = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 0,
         arboristIsActive: false,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       const sum = sumWeights(result);
@@ -23,10 +24,11 @@ describe('computeHarvestOutcomeWeights', () => {
 
     it('should conserve weight sum with 5 harvesters, no upgrades, no arborist', () => {
       const result = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 5,
         arboristIsActive: false,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       const sum = sumWeights(result);
@@ -35,10 +37,11 @@ describe('computeHarvestOutcomeWeights', () => {
 
     it('should conserve weight sum with 10 harvesters, arborist active, no upgrades', () => {
       const result = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 10,
         arboristIsActive: true,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       const sum = sumWeights(result);
@@ -47,7 +50,7 @@ describe('computeHarvestOutcomeWeights', () => {
 
     it('should conserve weight sum with 5 harvesters, all safe upgrades', () => {
       const result = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 5,
         arboristIsActive: true,
         upgrades: {
@@ -55,6 +58,7 @@ describe('computeHarvestOutcomeWeights', () => {
           training_program: true,
           selective_picking: true,
         },
+        tuning: TUNING.harvest,
       });
       
       const sum = sumWeights(result);
@@ -63,7 +67,7 @@ describe('computeHarvestOutcomeWeights', () => {
 
     it('should conserve weight sum with 8 harvesters, ladders_nets active', () => {
       const result = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 8,
         arboristIsActive: true,
         upgrades: {
@@ -72,6 +76,7 @@ describe('computeHarvestOutcomeWeights', () => {
           selective_picking: true,
           ladders_nets: true,
         },
+        tuning: TUNING.harvest,
       });
       
       const sum = sumWeights(result);
@@ -80,13 +85,14 @@ describe('computeHarvestOutcomeWeights', () => {
 
     it('should conserve weight sum with quality_inspector and arborist', () => {
       const result = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 3,
         arboristIsActive: true,
         upgrades: {
           quality_inspector: true,
           selective_picking: true,
         },
+        tuning: TUNING.harvest,
       });
       
       const sum = sumWeights(result);
@@ -97,10 +103,11 @@ describe('computeHarvestOutcomeWeights', () => {
   describe('Interrupted stability: interrupted_short weight remains unchanged', () => {
     it('should keep interrupted_short at base weight with 0 harvesters', () => {
       const result = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 0,
         arboristIsActive: false,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       const interrupted = findOutcome(result, 'interrupted_short');
@@ -109,10 +116,11 @@ describe('computeHarvestOutcomeWeights', () => {
 
     it('should keep interrupted_short at base weight with 5 harvesters', () => {
       const result = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 5,
         arboristIsActive: false,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       const interrupted = findOutcome(result, 'interrupted_short');
@@ -121,10 +129,11 @@ describe('computeHarvestOutcomeWeights', () => {
 
     it('should keep interrupted_short at base weight with 10 harvesters and arborist', () => {
       const result = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 10,
         arboristIsActive: true,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       const interrupted = findOutcome(result, 'interrupted_short');
@@ -133,7 +142,7 @@ describe('computeHarvestOutcomeWeights', () => {
 
     it('should keep interrupted_short at base weight with all upgrades', () => {
       const result = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 8,
         arboristIsActive: true,
         upgrades: {
@@ -143,6 +152,7 @@ describe('computeHarvestOutcomeWeights', () => {
           ladders_nets: true,
           quality_inspector: true,
         },
+        tuning: TUNING.harvest,
       });
       
       const interrupted = findOutcome(result, 'interrupted_short');
@@ -153,10 +163,11 @@ describe('computeHarvestOutcomeWeights', () => {
   describe('Non-negative weights: all weights >= 0', () => {
     it('should have non-negative weights with 0 harvesters', () => {
       const result = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 0,
         arboristIsActive: false,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       result.forEach(outcome => {
@@ -166,10 +177,11 @@ describe('computeHarvestOutcomeWeights', () => {
 
     it('should have non-negative weights with 5 harvesters, no upgrades', () => {
       const result = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 5,
         arboristIsActive: false,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       result.forEach(outcome => {
@@ -179,10 +191,11 @@ describe('computeHarvestOutcomeWeights', () => {
 
     it('should have non-negative weights with 10 harvesters, arborist active', () => {
       const result = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 10,
         arboristIsActive: true,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       result.forEach(outcome => {
@@ -192,7 +205,7 @@ describe('computeHarvestOutcomeWeights', () => {
 
     it('should have non-negative weights with all upgrades', () => {
       const result = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 8,
         arboristIsActive: true,
         upgrades: {
@@ -202,6 +215,7 @@ describe('computeHarvestOutcomeWeights', () => {
           ladders_nets: true,
           quality_inspector: true,
         },
+        tuning: TUNING.harvest,
       });
       
       result.forEach(outcome => {
@@ -211,7 +225,7 @@ describe('computeHarvestOutcomeWeights', () => {
 
     it('should have non-negative weights in extreme case: 20 harvesters, all upgrades', () => {
       const result = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 20,
         arboristIsActive: true,
         upgrades: {
@@ -221,6 +235,7 @@ describe('computeHarvestOutcomeWeights', () => {
           ladders_nets: true,
           quality_inspector: true,
         },
+        tuning: TUNING.harvest,
       });
       
       result.forEach(outcome => {
@@ -232,17 +247,19 @@ describe('computeHarvestOutcomeWeights', () => {
   describe('Specific weight adjustments', () => {
     it('should increase poor weight with more harvesters (no arborist, no upgrades)', () => {
       const baseline = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 0,
         arboristIsActive: false,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       const withHarvesters = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 5,
         arboristIsActive: false,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       const baselinePoor = findOutcome(baseline, 'poor').weight;
@@ -253,17 +270,19 @@ describe('computeHarvestOutcomeWeights', () => {
 
     it('should reduce poor weight increase when arborist is active', () => {
       const noArborist = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 10,
         arboristIsActive: false,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       const withArborist = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 10,
         arboristIsActive: true,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       const noArboristPoor = findOutcome(noArborist, 'poor').weight;
@@ -274,17 +293,19 @@ describe('computeHarvestOutcomeWeights', () => {
 
     it('should increase efficient weight when arborist is active', () => {
       const noArborist = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 5,
         arboristIsActive: false,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       const withArborist = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 5,
         arboristIsActive: true,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       const noArboristEfficient = findOutcome(noArborist, 'efficient').weight;
@@ -295,17 +316,19 @@ describe('computeHarvestOutcomeWeights', () => {
 
     it('should reduce poor weight with standardized_tools upgrade', () => {
       const noUpgrade = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 5,
         arboristIsActive: false,
         upgrades: {},
+        tuning: TUNING.harvest,
       });
       
       const withUpgrade = computeHarvestOutcomeWeights({
-        outcomes: BASE_HARVEST_OUTCOMES,
+        outcomes: TUNING.harvest.outcomes,
         harvesterCount: 5,
         arboristIsActive: false,
         upgrades: { standardized_tools: true },
+        tuning: TUNING.harvest,
       });
       
       const noUpgradePoor = findOutcome(noUpgrade, 'poor').weight;

--- a/prototypes/treeGroves/static/js/tuning.js
+++ b/prototypes/treeGroves/static/js/tuning.js
@@ -1,0 +1,58 @@
+// Centralized location for all game balance values
+// Organized by domain for scalability as we add processors and goods
+export const TUNING = {
+  // Grove: tree growth and capacity
+  grove: {
+    treeCapacity: 25,
+    treeGrowthPerSec: 1.0,
+  },
+
+  // Harvest: batch sizes, outcome probabilities, and modifiers
+  harvest: {
+    baseBatchSize: 10,
+    outcomes: [
+      { key: "interrupted_short", weight: 0.10, durationMs: 2000, collectedPct: 0.30, lostPct: 0.00 },
+      { key: "poor", weight: 0.25, durationMs: 5500, collectedPct: 0.50, lostPct: 0.50 },
+      { key: "normal", weight: 0.55, durationMs: 4500, collectedPct: 0.80, lostPct: 0.20 },
+      { key: "efficient", weight: 0.10, durationMs: 3500, collectedPct: 1.00, lostPct: 0.00 },
+    ],
+    poorWeightPerHarvester: 0.01,
+    poorArboristMultiplier: 0.5,
+    poorTrainingMultiplier: 0.5,
+    poorStandardizedToolsReduction: 0.08,
+    efficientArboristBonus: 0.05,
+    efficientSelectivePickingBonus: 0.06,
+    efficientLaddersNetsPerHarvester: 0.01,
+    efficientLaddersNetsCap: 0.08,
+    efficientQualityInspectorBonus: 0.08,
+  },
+
+  // Workers: hiring costs and production effects
+  workers: {
+    harvester: {
+      baseCost: 10,
+      costScale: 5,              // Cost increase per harvester hired
+      attemptBonusTiers: {       // Harvest batch size bonuses by count
+        tier1: { max: 5, bonus: 1 },     // First 5: +1 each
+        tier2: { max: 10, bonus: 0.5 },  // 6-10: +0.5 each
+        tier3: { bonus: 0.25 },          // 11+: +0.25 each
+      },
+      durationReductionPct: 0.04, // 4% speed per harvester
+      durationReductionCap: 0.25,  // Max 25% total speed boost
+    },
+  },
+
+  // Managers: hiring costs, salaries, and supervision effects
+  managers: {
+    arborist: {
+      hireCost: 50,
+      salaryPerMin: 0.2,         // Florins per minute
+    },
+  },
+
+  // Market: timing and pricing
+  market: {
+    tickSeconds: 12,
+    olivePriceFlorins: 1,
+  },
+};

--- a/prototypes/treeGroves/test-utils.js
+++ b/prototypes/treeGroves/test-utils.js
@@ -1,4 +1,5 @@
 // Test utilities - re-exports shared functions for testing
 // This file ensures tests use the exact same implementation as the game
 
-export { BASE_HARVEST_OUTCOMES, computeHarvestOutcomeWeights } from './static/js/harvestWeights.js';
+export { computeHarvestOutcomeWeights } from './static/js/harvestWeights.js';
+export { TUNING } from './static/js/tuning.js';


### PR DESCRIPTION
### Motivation
- Prevent tuning-derived values from being persisted so old saves don't lock in balance constants and tuning changes always take effect at load.
- Consolidate all harvest-related tuning into a single shared `TUNING.harvest` surface so harvest math and tests use one source of truth.
- Keep compatibility with existing saves by safely ignoring removed/derived fields on load.
- Clean up repository artifacts by ignoring `node_modules/` and macOS metadata files.

### Description
- Save/load hygiene: implemented a whitelist-based persistence strategy that only stores true player state; added `PERSISTED_STATE_KEYS`, `createDefaultState()`, `pickPersistedState()` and `buildPersistedState()` and changed `saveGame()` / `loadGame()` to merge persisted keys into defaults so tuning-derived fields are always re-derived from `TUNING` at runtime (`prototypes/treeGroves/static/js/game.js`).
- Harvest tuning ownership: moved harvest tuning and outcome definitions into a shared `TUNING` module (`prototypes/treeGroves/static/js/tuning.js`) and updated `harvestConfig` to use `TUNING.harvest.outcomes` (`game.js`).
- Threaded tuning into harvest math: refactored `computeHarvestOutcomeWeights(...)` to accept a `tuning` parameter and replaced hardcoded numeric literals with tuning values (`prototypes/treeGroves/static/js/harvestWeights.js`).
- Tests & utilities: updated `test-utils.js` to re-export `TUNING`, and updated `harvest-weights.test.js` to use `TUNING.harvest.outcomes` and pass `tuning: TUNING.harvest` into the function so tests share the same tuning source (`prototypes/treeGroves/test-utils.js`, `prototypes/treeGroves/harvest-weights.test.js`).
- Repo hygiene: added `__MACOSX/` and `node_modules/` to `.gitignore` and updated documentation references in `TEST_README.md`.

### Testing
- Ran unit tests with `npm test` inside the prototype directory and all tests passed: `vitest` run reported 1 file, 19 tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983b9a4da60832e8c24aaad639d4a45)